### PR TITLE
drop trailing dash from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6


### PR DESCRIPTION
would probably still work on prereleases, but cleaner to use release now that it's out